### PR TITLE
Implementando spring security e camada de autenticação

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,25 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
+
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.4.0</version>
+		</dependency>
+
+		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/ParkCore/controller/AuthController.java
+++ b/src/main/java/com/ParkCore/controller/AuthController.java
@@ -1,12 +1,7 @@
 package com.ParkCore.controller;
 
-import java.util.Optional;
-
-import org.hibernate.ObjectNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,12 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ParkCore.dto.LoginRequestDTO;
 import com.ParkCore.dto.RegisterRequestDTO;
-import com.ParkCore.dto.ResponseDTO;
-import com.ParkCore.enums.UserRole;
-import com.ParkCore.exceptions.BadRequestException;
-import com.ParkCore.infra.security.TokenService;
-import com.ParkCore.model.User;
-import com.ParkCore.repository.UserRepository;
+import com.ParkCore.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,38 +17,20 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
-	
-	private final UserRepository repository;
-	private final PasswordEncoder passwordEncoder;
-	private final TokenService tokenService;
+	@Autowired
+	private UserService userService;
 	
 	@PostMapping("/login")
     public ResponseEntity login(@RequestBody LoginRequestDTO body){
-        var user = this.repository.findByName(body.getName()).orElseThrow(() -> new UsernameNotFoundException("Usuario não encontrado"));
-        if(passwordEncoder.matches(body.getPassword(), user.getPassword())) {
-            var token = this.tokenService.generateToken(user);
-            return ResponseEntity.ok(new ResponseDTO(user.getName(), token));
-        }
-        	throw new ObjectNotFoundException(user.getId(), User.class.getName());
+        var response = userService.login(body);
+        return ResponseEntity.ok(response);
     }
 
 
     @PostMapping("/register")
     public ResponseEntity register(@RequestBody RegisterRequestDTO body){
-        Optional<User> user = this.repository.findByName(body.getName());
-
-        if(user.isEmpty()) {
-        	var newUser = new User();
-            newUser.setName(body.getName());
-            newUser.setPassword(passwordEncoder.encode(body.getPassword()));
-            //In this phase, it's interesting to use Flyway.
-            newUser.setRole(UserRole.USER);
-            this.repository.save(newUser);
-
-            String token = this.tokenService.generateToken(newUser);
-            return ResponseEntity.ok(new ResponseDTO(newUser.getName(), token));
-        }
-        throw new BadRequestException("Não foi possivel registrar o usuario!!");
+        var response = userService.register(body);
+        return ResponseEntity.ok(response);
     }
 	
 }

--- a/src/main/java/com/ParkCore/controller/AuthController.java
+++ b/src/main/java/com/ParkCore/controller/AuthController.java
@@ -34,9 +34,9 @@ public class AuthController {
 	
 	@PostMapping("/login")
     public ResponseEntity login(@RequestBody LoginRequestDTO body){
-        User user = this.repository.findByName(body.getName()).orElseThrow(() -> new UsernameNotFoundException("Usuario não encontrado"));
+        var user = this.repository.findByName(body.getName()).orElseThrow(() -> new UsernameNotFoundException("Usuario não encontrado"));
         if(passwordEncoder.matches(body.getPassword(), user.getPassword())) {
-            String token = this.tokenService.generateToken(user);
+            var token = this.tokenService.generateToken(user);
             return ResponseEntity.ok(new ResponseDTO(user.getName(), token));
         }
         	throw new ObjectNotFoundException(user.getId(), User.class.getName());
@@ -48,7 +48,7 @@ public class AuthController {
         Optional<User> user = this.repository.findByName(body.getName());
 
         if(user.isEmpty()) {
-        	User newUser = new User();
+        	var newUser = new User();
             newUser.setName(body.getName());
             newUser.setPassword(passwordEncoder.encode(body.getPassword()));
             //In this phase, it's interesting to use Flyway.

--- a/src/main/java/com/ParkCore/controller/AuthController.java
+++ b/src/main/java/com/ParkCore/controller/AuthController.java
@@ -1,0 +1,64 @@
+package com.ParkCore.controller;
+
+import java.util.Optional;
+
+import org.hibernate.ObjectNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ParkCore.dto.LoginRequestDTO;
+import com.ParkCore.dto.RegisterRequestDTO;
+import com.ParkCore.dto.ResponseDTO;
+import com.ParkCore.enums.UserRole;
+import com.ParkCore.exceptions.BadRequestException;
+import com.ParkCore.infra.security.TokenService;
+import com.ParkCore.model.User;
+import com.ParkCore.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+	
+	private final UserRepository repository;
+	private final PasswordEncoder passwordEncoder;
+	private final TokenService tokenService;
+	
+	@PostMapping("/login")
+    public ResponseEntity login(@RequestBody LoginRequestDTO body){
+        User user = this.repository.findByName(body.getName()).orElseThrow(() -> new UsernameNotFoundException("Usuario não encontrado"));
+        if(passwordEncoder.matches(body.getPassword(), user.getPassword())) {
+            String token = this.tokenService.generateToken(user);
+            return ResponseEntity.ok(new ResponseDTO(user.getName(), token));
+        }
+        	throw new ObjectNotFoundException(user.getId(), User.class.getName());
+    }
+
+
+    @PostMapping("/register")
+    public ResponseEntity register(@RequestBody RegisterRequestDTO body){
+        Optional<User> user = this.repository.findByName(body.getName());
+
+        if(user.isEmpty()) {
+        	User newUser = new User();
+            newUser.setName(body.getName());
+            newUser.setPassword(passwordEncoder.encode(body.getPassword()));
+            //In this phase, it's interesting to use Flyway.
+            newUser.setRole(UserRole.USER);
+            this.repository.save(newUser);
+
+            String token = this.tokenService.generateToken(newUser);
+            return ResponseEntity.ok(new ResponseDTO(newUser.getName(), token));
+        }
+        throw new BadRequestException("Não foi possivel registrar o usuario!!");
+    }
+	
+}

--- a/src/main/java/com/ParkCore/controller/UserController.java
+++ b/src/main/java/com/ParkCore/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.ParkCore.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ParkCore.model.User;
+import com.ParkCore.service.UserService;
+
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+
+	@Autowired
+	private UserService userService;
+	
+	@PostMapping("/create")
+	public User CreateUser(@RequestBody User user) {
+		return userService.CreateUser(user);
+	}
+
+	@PutMapping("/update/{id}")
+	public User updateUser(@RequestBody User user, @PathVariable Long id) {
+		return userService.updateUser(user, id);
+	}
+
+	@GetMapping
+	public List<User> findAllUsers(){
+		return userService.findAllUsers();
+	}
+	
+}

--- a/src/main/java/com/ParkCore/controller/UserController.java
+++ b/src/main/java/com/ParkCore/controller/UserController.java
@@ -23,7 +23,7 @@ public class UserController {
 	private UserService userService;
 	
 	@PostMapping("/create")
-	public User CreateUser(@RequestBody User user) {
+	public User createUser(@RequestBody User user) {
 		return userService.CreateUser(user);
 	}
 

--- a/src/main/java/com/ParkCore/dto/LoginRequestDTO.java
+++ b/src/main/java/com/ParkCore/dto/LoginRequestDTO.java
@@ -1,0 +1,17 @@
+package com.ParkCore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginRequestDTO {
+	
+	private String name;
+	private String password;
+	
+}

--- a/src/main/java/com/ParkCore/dto/RegisterRequestDTO.java
+++ b/src/main/java/com/ParkCore/dto/RegisterRequestDTO.java
@@ -1,0 +1,19 @@
+package com.ParkCore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import com.ParkCore.enums.UserRole;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegisterRequestDTO {
+
+	private String name;
+	private String password;
+	private UserRole role;
+	
+}

--- a/src/main/java/com/ParkCore/dto/ResponseDTO.java
+++ b/src/main/java/com/ParkCore/dto/ResponseDTO.java
@@ -1,0 +1,17 @@
+package com.ParkCore.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseDTO {
+
+	private String name;
+	private String token;
+	
+}

--- a/src/main/java/com/ParkCore/enums/UserRole.java
+++ b/src/main/java/com/ParkCore/enums/UserRole.java
@@ -1,0 +1,20 @@
+package com.ParkCore.enums;
+
+public enum UserRole {
+	
+	ADMIN("Admin"),
+	USER("User");
+	
+	private String role;
+	
+	UserRole(String role) {
+		this.role = role;
+	}
+
+	public String getRole() {
+		return role;
+	}
+	
+	
+	
+}

--- a/src/main/java/com/ParkCore/infra/cors/CorsConfig.java
+++ b/src/main/java/com/ParkCore/infra/cors/CorsConfig.java
@@ -1,0 +1,19 @@
+package com.ParkCore.infra.cors;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer{
+
+	//Which port will the front end run?
+	
+	@Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5500")
+                .allowedMethods("GET", "POST", "DELETE", "PUT");
+    }
+	
+}

--- a/src/main/java/com/ParkCore/infra/security/CustomUserDetailsService.java
+++ b/src/main/java/com/ParkCore/infra/security/CustomUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.ParkCore.infra.security;
+
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import com.ParkCore.model.User;
+import com.ParkCore.repository.UserRepository;
+
+
+@Component
+public class CustomUserDetailsService implements UserDetailsService{
+
+	@Autowired
+    private UserRepository repository;
+    
+	 public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+	        User user = repository.findByName(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+	       
+	        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(user.getRole().getRole().toUpperCase());
+	        
+	        return new org.springframework.security.core.userdetails.User(
+	            user.getName(), 
+	            user.getPassword(), 
+	            Collections.singleton(authority)
+	        );
+	    }
+}

--- a/src/main/java/com/ParkCore/infra/security/CustomUserDetailsService.java
+++ b/src/main/java/com/ParkCore/infra/security/CustomUserDetailsService.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
-import com.ParkCore.model.User;
+import org.springframework.security.core.userdetails.User;
 import com.ParkCore.repository.UserRepository;
 
 
@@ -20,11 +20,11 @@ public class CustomUserDetailsService implements UserDetailsService{
     private UserRepository repository;
     
 	 public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-	        User user = repository.findByName(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+	        var user = repository.findByName(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
 	       
 	        SimpleGrantedAuthority authority = new SimpleGrantedAuthority(user.getRole().getRole().toUpperCase());
 	        
-	        return new org.springframework.security.core.userdetails.User(
+	        return new User(
 	            user.getName(), 
 	            user.getPassword(), 
 	            Collections.singleton(authority)

--- a/src/main/java/com/ParkCore/infra/security/SecurityConfig.java
+++ b/src/main/java/com/ParkCore/infra/security/SecurityConfig.java
@@ -1,0 +1,51 @@
+package com.ParkCore.infra.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+	@Autowired
+    private CustomUserDetailsService userDetailsService;
+
+    @Autowired
+    SecurityFilter securityFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        		http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/register").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/ParkCore/infra/security/SecurityFilter.java
+++ b/src/main/java/com/ParkCore/infra/security/SecurityFilter.java
@@ -1,0 +1,50 @@
+package com.ParkCore.infra.security;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.ParkCore.model.User;
+import com.ParkCore.repository.UserRepository;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class SecurityFilter extends OncePerRequestFilter{
+
+
+	 @Autowired
+	    TokenService tokenService;
+	    @Autowired
+	    UserRepository userRepository;
+	
+	    @Override
+	    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+	        var token = this.recoverToken(request);
+	        var login = tokenService.validateToken(token);
+
+	        if(login != null){
+	            User user = userRepository.findByName(login).orElseThrow(() -> new RuntimeException("User Not Found"));
+	            var authorities = Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));
+	            var authentication = new UsernamePasswordAuthenticationToken(user, null, authorities);
+	            SecurityContextHolder.getContext().setAuthentication(authentication);
+	        }
+	        filterChain.doFilter(request, response);
+	    }
+
+	    private String recoverToken(HttpServletRequest request){
+	        var authHeader = request.getHeader("Authorization");
+	        if(authHeader == null) return null;
+	        return authHeader.replace("Bearer ", "");
+	    }
+	
+}

--- a/src/main/java/com/ParkCore/infra/security/TokenService.java
+++ b/src/main/java/com/ParkCore/infra/security/TokenService.java
@@ -42,7 +42,7 @@ public class TokenService {
 
     public String validateToken(String token){
         try {
-            Algorithm algorithm = Algorithm.HMAC256(secret);
+            var algorithm = Algorithm.HMAC256(secret);
             return JWT.require(algorithm)
                     .withIssuer("login-auth-api")
                     .build()

--- a/src/main/java/com/ParkCore/infra/security/TokenService.java
+++ b/src/main/java/com/ParkCore/infra/security/TokenService.java
@@ -1,0 +1,59 @@
+package com.ParkCore.infra.security;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.ParkCore.model.User;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+
+
+@Service
+public class TokenService {
+
+	@Value("${api.security.token.secret}")
+    private String secret;
+    public String generateToken(User user){
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+            
+           String role = user.getRole().getRole().toUpperCase();
+            		
+            
+            String token = JWT.create()
+                    .withIssuer("login-auth-api")
+                    .withSubject(user.getName())
+                    .withClaim("roles", Collections.singletonList(role))
+                    .withExpiresAt(this.generateExpirationDate())
+                    .sign(algorithm);
+            return token;
+        } catch (JWTCreationException exception){
+            throw new RuntimeException("Error while authenticating");
+        }
+    }
+
+    public String validateToken(String token){
+        try {
+            Algorithm algorithm = Algorithm.HMAC256(secret);
+            return JWT.require(algorithm)
+                    .withIssuer("login-auth-api")
+                    .build()
+                    .verify(token)
+                    .getSubject();
+        } catch (JWTVerificationException exception) {
+            return null;
+        }
+    }
+
+    private Instant generateExpirationDate(){
+        return LocalDateTime.now().plusHours(2).toInstant(ZoneOffset.of("-03:00"));
+    }
+	
+}

--- a/src/main/java/com/ParkCore/infra/security/TokenService.java
+++ b/src/main/java/com/ParkCore/infra/security/TokenService.java
@@ -20,14 +20,15 @@ public class TokenService {
 
 	@Value("${api.security.token.secret}")
     private String secret;
+	
     public String generateToken(User user){
         try {
-            Algorithm algorithm = Algorithm.HMAC256(secret);
+            var algorithm = Algorithm.HMAC256(secret);
             
-           String role = user.getRole().getRole().toUpperCase();
+           var role = user.getRole().getRole().toUpperCase();
             		
             
-            String token = JWT.create()
+            var token = JWT.create()
                     .withIssuer("login-auth-api")
                     .withSubject(user.getName())
                     .withClaim("roles", Collections.singletonList(role))

--- a/src/main/java/com/ParkCore/model/User.java
+++ b/src/main/java/com/ParkCore/model/User.java
@@ -1,0 +1,41 @@
+package com.ParkCore.model;
+
+import com.ParkCore.enums.UserRole;
+
+import jakarta.annotation.Generated;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "User_Pk")
+public class User {
+	
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	
+	@NotBlank
+	@NotNull
+	@Column(length = 200, nullable = false)
+	private String name;
+	
+	@NotBlank
+	@NotNull
+	@Column(nullable = false)
+	private String password;
+	
+	@Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+	private UserRole role;
+	
+}

--- a/src/main/java/com/ParkCore/repository/UserRepository.java
+++ b/src/main/java/com/ParkCore/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.ParkCore.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ParkCore.model.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>{
+
+	Optional<User> findByName(String name);
+	
+}

--- a/src/main/java/com/ParkCore/service/UserService.java
+++ b/src/main/java/com/ParkCore/service/UserService.java
@@ -1,11 +1,21 @@
 package com.ParkCore.service;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.hibernate.ObjectNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.ParkCore.dto.LoginRequestDTO;
+import com.ParkCore.dto.RegisterRequestDTO;
+import com.ParkCore.dto.ResponseDTO;
+import com.ParkCore.enums.UserRole;
+import com.ParkCore.exceptions.BadRequestException;
+import com.ParkCore.infra.security.TokenService;
 import com.ParkCore.model.User;
 import com.ParkCore.repository.UserRepository;
 
@@ -16,6 +26,9 @@ public class UserService {
 	private UserRepository userRepository;
 	
 	@Autowired
+	private TokenService tokenService;
+	
+	@Autowired
 	private PasswordEncoder passwordEncoder;
 	
 	//Create a user with encrypted password
@@ -23,7 +36,7 @@ public class UserService {
 		var userCreate = new User();
 		
 		userCreate.setName(user.getName());
-		String encrypt = passwordEncoder.encode(user.getPassword());
+		var encrypt = passwordEncoder.encode(user.getPassword());
 		userCreate.setPassword(encrypt);
 		userCreate.setRole(user.getRole());
 		return userRepository.save(userCreate);
@@ -37,9 +50,9 @@ public class UserService {
 			throw new RuntimeException("Can´t find a user with this id");
 		}
 		
-		User userMod = userFind.get();
+		var userMod = userFind.get();
 		userMod.setName(user.getName());
-		String encrypt = passwordEncoder.encode(user.getPassword());
+		var encrypt = passwordEncoder.encode(user.getPassword());
 		userMod.setPassword(encrypt);
 		userMod.setRole(user.getRole());
 		return userRepository.save(userMod);
@@ -48,6 +61,35 @@ public class UserService {
 	
 	public List<User> findAllUsers(){
 		return userRepository.findAll();
+	}
+	
+	
+	public ResponseEntity<ResponseDTO> login(LoginRequestDTO body) {
+		var user = userRepository.findByName(body.getName()).orElseThrow(() -> new UsernameNotFoundException("User not found!"));
+        if(passwordEncoder.matches(body.getPassword(), user.getPassword())) {
+            var token = tokenService.generateToken(user);
+            return ResponseEntity.ok(new ResponseDTO(user.getName(), token));
+        }
+        	throw new ObjectNotFoundException(user.getId(), User.class.getName());
+	}
+	
+	public ResponseEntity<ResponseDTO> register(RegisterRequestDTO body){
+		
+		var user = userRepository.findByName(body.getName());
+
+        if(user.isEmpty()) {
+        	var newUser = new User();
+            newUser.setName(body.getName());
+            newUser.setPassword(passwordEncoder.encode(body.getPassword()));
+            //In this phase, it's interesting to use Flyway.
+            newUser.setRole(UserRole.USER);
+            userRepository.save(newUser);
+
+            var token = this.tokenService.generateToken(newUser);
+            return ResponseEntity.ok(new ResponseDTO(newUser.getName(), token));
+        }
+        throw new BadRequestException("Unable to register the user!!");
+		
 	}
 	
 	

--- a/src/main/java/com/ParkCore/service/UserService.java
+++ b/src/main/java/com/ParkCore/service/UserService.java
@@ -1,0 +1,55 @@
+package com.ParkCore.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.ParkCore.model.User;
+import com.ParkCore.repository.UserRepository;
+
+@Service
+public class UserService {
+
+	@Autowired
+	private UserRepository userRepository;
+	
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+	
+	//Create a user with encrypted password
+	public User CreateUser(User user) {
+		var userCreate = new User();
+		
+		userCreate.setName(user.getName());
+		String encrypt = passwordEncoder.encode(user.getPassword());
+		userCreate.setPassword(encrypt);
+		userCreate.setRole(user.getRole());
+		return userRepository.save(userCreate);
+	}
+	
+	
+	public User updateUser(User user, Long id) {
+		var userFind = userRepository.findById(id);
+		
+		if(!userFind.isPresent()) {
+			throw new RuntimeException("Can´t find a user with this id");
+		}
+		
+		User userMod = userFind.get();
+		userMod.setName(user.getName());
+		String encrypt = passwordEncoder.encode(user.getPassword());
+		userMod.setPassword(encrypt);
+		userMod.setRole(user.getRole());
+		return userRepository.save(userMod);
+	}
+	
+	
+	public List<User> findAllUsers(){
+		return userRepository.findAll();
+	}
+	
+	
+	
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.username=postgres
 spring.datasource.password=12345
 spring.jpa.hibernate.ddl-auto=update
+
+api.security.token.secret=secret-key


### PR DESCRIPTION
Foi adicionado uma camada de autenticação à API, garantindo que apenas usuários autenticados possam acessar determinados endpoints. A implementação utilizou Spring Security para gerenciar a autenticação e a autorização de forma eficiente e segura.

Nota: Fiz a liberação de alguns endpoints, dentre eles aquele onde se encontra o swagger